### PR TITLE
Fix bet lookup and reset active numbers

### DIFF
--- a/src/class/Player.ts
+++ b/src/class/Player.ts
@@ -35,6 +35,7 @@ export class Player {
 
   private resetActiveBets() {
     this.activeBets = [];
+    this.activeBettedNumbers = [];
   }
 
   public placeBet({ eventId, stake }: BetConstructorArgs) {
@@ -48,9 +49,9 @@ export class Player {
     const event = Roulette.getEventById(eventId);
 
     // if bet already exists, add stake to it. If not create one.
-    const idx = this.activeBets.findIndex((bet) => {
-      bet.event.isEqual(event);
-    });
+    const idx = this.activeBets.findIndex((bet) =>
+      bet.event.isEqual(event)
+    );
     if (idx !== -1) {
       this.activeBets[idx].increaseBet(stake);
     } else {


### PR DESCRIPTION
## Summary
- fix bet merging logic to properly detect existing bets
- clear active betted numbers when resetting bets

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af67b11920832ea63deadc0a81fa66